### PR TITLE
Fix GFA1 path overlaps

### DIFF
--- a/src/CdBG_GFA_Writer.cpp
+++ b/src/CdBG_GFA_Writer.cpp
@@ -591,7 +591,7 @@ void CdBG<k>::append_link_to_path(const uint16_t thread_id, const Oriented_Uniti
     p_buffer += (right_unitig.dir == cuttlefish::FWD ? "+" : "-");
 
     std::string& o_buffer = overlap_buffer[thread_id];
-    o_buffer += ",";
+    if (!o_buffer.empty()) o_buffer += ",";
     o_buffer += fmt::format_int(right_unitig.start_kmer_idx == left_unitig.end_kmer_idx + 1 ? k - 1 : 0).c_str();
     o_buffer += "M";
 
@@ -797,10 +797,6 @@ void CdBG<k>::write_gfa_path(const std::string& path_name)
         output << "*";  // Write an empty CIGAR string at the 'Overlaps' field.
     else
     {
-        // The first overlap of the path (not inferrable from the path output files).
-        const uint16_t overlap = (right_unitig.start_kmer_idx == left_unitig.end_kmer_idx +  1 ? k - 1 : 0);
-        output << overlap << "M";
-
         // Copy the thread-specific overlap output file contents to the GFA output file.
         for(uint16_t t_id = 0; t_id < thread_count; ++t_id)
         {


### PR DESCRIPTION
Hi and thanks a lot for your work on Cuttlefish!

I've been working on a GFA1 file parser and have used Cuttlefish to generate GFA1 files. In doing so, I noticed that the Path lines output by Cuttlefish are ambiguous and break the GFA 1.0 Format Specification. Quoting https://github.com/GFA-spec/GFA-spec/blob/master/GFA1.md#p-path-line:
>If specified, the Overlaps field must have one fewer values than the number of segment names and orientations in the SegmentNames field.

However, Cuttlefish currently outputs an extra overlap value.

Here are two small reproducible examples which highlight the issue. First, consider the FASTA file with contents:
```
>Example1.fasta
CTANAAC
```
I used the symbol 'N' to induce a zero overlap link so that we can track which overlaps correspond to which links. Running Cuttlefish (and KMC) on this file with `-k 3` produces the GFA1 file with contents:
```
H	VN:Z:1.0
P	Reference:1_Sequence:Example1.fasta	1+,0+	0M,0M
S	1	CTA	LN:i:3
S	0	AAC	LN:i:3
L	1	+	0	+	0M
```
Here, "0M" is given twice. The correct overlap output for the path would be a single "0M". Next, also consider the FASTA file with contents:
```
>Example2.fasta
ACTANAACT
```
and the produced GFA1 file with contents:
```
H	VN:Z:1.0
P	Reference:1_Sequence:Example2.fasta	2+,1+,0+,2+	2M,2M,0M,2M
S	2	ACT	LN:i:3
S	1	CTA	LN:i:3
L	2	+	1	+	2M
S	0	AAC	LN:i:3
L	1	+	0	+	0M
L	0	+	2	+	2M
```
Here, the correct overlap output would be "2M,0M,2M". 

It appears that the overlap buffer for each thread already contains the correct overlaps and the manually output first overlap of the path is a duplicate. My proposed fix is to simply output the overlap buffer (without the first comma). After applying the fix, Cuttlefish produces the GFA1 files
```
H	VN:Z:1.0
P	Reference:1_Sequence:Example1.fasta	1+,0+	0M
S	1	CTA	LN:i:3
S	0	AAC	LN:i:3
L	1	+	0	+	0M
``` 
and
```
H	VN:Z:1.0
P	Reference:1_Sequence:Example1.fasta	2+,1+,0+,2+	2M,0M,2M
S	2	ACT	LN:i:3
S	1	CTA	LN:i:3
L	2	+	1	+	2M
S	0	AAC	LN:i:3
L	1	+	0	+	0M
L	0	+	2	+	2M
```
which are correct.
