### PR TITLE
Fix GFA1 path overlaps, revisited

### DIFF
--- a/src/CdBG_GFA_Writer.cpp
+++ b/src/CdBG_GFA_Writer.cpp
@@ -591,7 +591,7 @@ void CdBG<k>::append_link_to_path(const uint16_t thread_id, const Oriented_Uniti
     p_buffer += (right_unitig.dir == cuttlefish::FWD ? "+" : "-");
 
     std::string& o_buffer = overlap_buffer[thread_id];
-    if (!o_buffer.empty()) o_buffer += ",";
+    if (thread_id > 0 || !o_buffer.empty()) o_buffer += ",";
     o_buffer += fmt::format_int(right_unitig.start_kmer_idx == left_unitig.end_kmer_idx + 1 ? k - 1 : 0).c_str();
     o_buffer += "M";
 

--- a/src/CdBG_GFA_Writer.cpp
+++ b/src/CdBG_GFA_Writer.cpp
@@ -591,7 +591,7 @@ void CdBG<k>::append_link_to_path(const uint16_t thread_id, const Oriented_Uniti
     p_buffer += (right_unitig.dir == cuttlefish::FWD ? "+" : "-");
 
     std::string& o_buffer = overlap_buffer[thread_id];
-    o_buffer += ",";
+    if (!o_buffer.empty()) o_buffer += ",";
     o_buffer += fmt::format_int(right_unitig.start_kmer_idx == left_unitig.end_kmer_idx + 1 ? k - 1 : 0).c_str();
     o_buffer += "M";
 
@@ -797,10 +797,6 @@ void CdBG<k>::write_gfa_path(const std::string& path_name)
         output << "*";  // Write an empty CIGAR string at the 'Overlaps' field.
     else
     {
-        // The first overlap of the path (not inferrable from the path output files).
-        const uint16_t overlap = (right_unitig.start_kmer_idx == left_unitig.end_kmer_idx +  1 ? k - 1 : 0);
-        output << overlap << "M";
-
         // Copy the thread-specific overlap output file contents to the GFA output file.
         for(uint16_t t_id = 0; t_id < thread_count; ++t_id)
         {


### PR DESCRIPTION
Hello again @jamshed,

Thanks for your quick reply to my earlier pull request (https://github.com/COMBINE-lab/cuttlefish/issues/8). I also much appreciate that you took the issue under work immediately!

I've been away from this work for a couple weeks and now that I've returned, I noticed that my previous bug fix was issued hastily. I am embarrassed having to submit a new pull request on the same matter.

In the previously proposed fix, it is indeed true that the overlap buffer(s) already contain the correct overlaps and thus removing the manually output first overlap corrects the issue. However, the proposed change to writing the overlap buffers introduced a new bug. My earlier fix to remove the first comma only works in a single-threaded context. The commas are naturally necessary when the overlap buffers of multiple threads are concatenated, otherwise the first overlap from each thread won't be separated from the last overlap of the previous thread. E.g., "...,30M,30M,..." becomes "...,30M30M,...".

Since the thread-specific overlap output files are written to the GFA output file in order, changing the line
`if (!o_buffer.empty()) o_buffer += ",";`
to
`if (thread_id > 0 || !o_buffer.empty()) o_buffer += ",";`
adds a comma in front of the overlap buffers of other threads, while preventing the first thread from having the erroneous extra comma.

While this fixes the new bug, and hopefully doesn't introduce further new bugs, you might of course want to consider a cleaner implementation. Fortunately the previous fix had not made its way to the main branch yet. Since the only problem with the main branch version is that the first overlap in the GFA1 path overlaps fields is a duplicate, current users can either edit it out by some script or implement an indexing correction in their code bases if they need or use the overlaps fields.

Best regards,
Juri Kuronen