### PR TITLE
Building on Apple M1 / M2 Silicon

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,14 +82,25 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
         OUTPUT_VARIABLE L1_CACHE_LINE_SIZE
     )
 elseif(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-    # OSX has `getconf`, but doesn't report `LEVEL1_DCACHE_LINESIZE`;
-    # so we instead use `sysctl` for the corresponding variable.
-    execute_process(
-        COMMAND sysctl machdep.cpu.cache.linesize
-        COMMAND awk "{print $2}"
-        COMMAND tr -d '\n'
-        OUTPUT_VARIABLE L1_CACHE_LINE_SIZE
-    )
+    if(CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "x86_64")
+        # OSX has `getconf`, but doesn't report `LEVEL1_DCACHE_LINESIZE`;
+        # so we instead use `sysctl` for the corresponding variable.
+        execute_process(
+            COMMAND sysctl machdep.cpu.cache.linesize
+            COMMAND awk "{print $2}"
+            COMMAND tr -d '\n'
+            OUTPUT_VARIABLE L1_CACHE_LINE_SIZE
+        )
+    elseif(CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "arm64")
+        execute_process(
+            COMMAND sysctl hw.cachelinesize
+            COMMAND awk "{print $2}"
+            COMMAND tr -d '\n'
+            OUTPUT_VARIABLE L1_CACHE_LINE_SIZE
+        )
+    else()
+        message(FATAL_ERROR "Unable to identify Apple Silicon processor architecture")
+    endif()
 
     # Later on, jemalloc will complain if the C compiler 
     # hasn't been properly set.
@@ -175,7 +186,7 @@ ExternalProject_Add(prj_kmc
     DOWNLOAD_COMMAND    curl -k -L https://github.com/refresh-bio/KMC/archive/refs/tags/v3.2.1.tar.gz -o KMC-3.2.1.tar.gz &&
                         tar -xzf KMC-3.2.1.tar.gz &&
                         rm KMC-3.2.1.tar.gz
-    PATCH_COMMAND       patch --strip 1 < ${CMAKE_SOURCE_DIR}/patches/kmc_patch.diff
+    PATCH_COMMAND       patch --strip 1 < ${CMAKE_SOURCE_DIR}/patches/kmc-v3.2.1_cuttlefish-dev.diff
     SOURCE_DIR          ${CMAKE_SOURCE_DIR}/external/KMC-3.2.1
     BUILD_IN_SOURCE     TRUE
     INSTALL_DIR         ${CMAKE_SOURCE_DIR}/external/

--- a/patches/kmc-v3.2.1_cuttlefish-dev.diff
+++ b/patches/kmc-v3.2.1_cuttlefish-dev.diff
@@ -1,0 +1,269 @@
+diff --git a/Makefile b/Makefile
+index bc07d35..2b351b9 100644
+--- a/Makefile
++++ b/Makefile
+@@ -13,15 +13,11 @@ OUT_BIN_DIR = bin
+ OUT_INCLUDE_DIR = include
+ 
+ ifeq ($(UNAME_S),Darwin)
+-	CC = /usr/local/bin/g++-10
+-
+-	CFLAGS	= -Wall -O3 -m64 -static-libgcc -static-libstdc++ -pthread -std=c++14
+-	CLINK	= -lm -static-libgcc -static-libstdc++ -O3 -pthread -std=c++14
++	CFLAGS	= -Wall -O3 -m64 -pthread -std=c++14
++	CLINK	= -lm -lbz2 -lc++ -lz -O3 -pthread -std=c++14
+ 
+ 	PY_KMC_API_CFLAGS = -Wl,-undefined,dynamic_lookup -fPIC -Wall -shared -std=c++14 -O3
+ else
+-	CC 	= g++
+-
+ 	CFLAGS	= -Wall -O3 -m64 -static -Wl,--whole-archive -lpthread -Wl,--no-whole-archive -std=c++14
+ 	CLINK	= -lm -static -O3 -Wl,--whole-archive -lpthread -Wl,--no-whole-archive -std=c++14
+ 
+@@ -53,15 +49,15 @@ $(KMC_MAIN_DIR)/kmc_runner.o
+ ifeq ($(UNAME_S),Darwin)
+ 	RADULS_OBJS =
+ 
+-	KMC_LIBS = \
+-	$(KMC_MAIN_DIR)/libs/libz.1.2.5.dylib \
+-	$(KMC_MAIN_DIR)/libs/libbz2.1.0.5.dylib
++	#KMC_LIBS = \
++	#$(KMC_MAIN_DIR)/libs/libz.1.2.5.dylib \
++	#$(KMC_MAIN_DIR)/libs/libbz2.1.0.5.dylib
+ 
+-	KMC_TOOLS_LIBS = \
+-	$(KMC_TOOLS_DIR)/libs/libz.1.2.5.dylib \
+-	$(KMC_TOOLS_DIR)/libs/libbz2.1.0.5.dylib
++	#KMC_TOOLS_LIBS = \
++	#$(KMC_TOOLS_DIR)/libs/libz.1.2.5.dylib \
++	#$(KMC_TOOLS_DIR)/libs/libbz2.1.0.5.dylib
+ 
+-	LIB_KMC_CORE = $(OUT_BIN_DIR)/libkmc_core.mac.a
++	LIB_KMC_CORE = $(OUT_BIN_DIR)/libkmc_core.a
+ else
+ 	RADULS_OBJS = \
+ 	$(KMC_MAIN_DIR)/raduls_sse2.o \
+@@ -106,8 +102,19 @@ $(KMC_TOOLS_DIR)/fastq_writer.o \
+ $(KMC_TOOLS_DIR)/percent_progress.o \
+ $(KMC_TOOLS_DIR)/kff_info_reader.o
+ 
++SIMDE_DIR = $(KMC_MAIN_DIR)/simde
+ 
+-$(KMC_CLI_OBJS) $(KMC_CORE_OBJS) $(KMC_DUMP_OBJS) $(KMC_API_OBJS) $(KFF_OBJS) $(KMC_TOOLS_OBJS): %.o: %.cpp
++# Download amalgamated SIMDE library
++$(SIMDE_DIR):
++	curl -k -L https://github.com/simd-everywhere/simde/releases/download/v0.7.2/simde-amalgamated-0.7.2.tar.xz -o $(KMC_MAIN_DIR)/simde-amalgamated-0.7.2.tar.xz && \
++    tar -C $(KMC_MAIN_DIR) -xvf $(KMC_MAIN_DIR)/simde-amalgamated-0.7.2.tar.xz && \
++	rm  $(KMC_MAIN_DIR)/simde-amalgamated-0.7.2.tar.xz && \
++	mv $(KMC_MAIN_DIR)/simde-amalgamated-0.7.2 $@
++
++$(KMC_CLI_OBJS) $(KMC_DUMP_OBJS) $(KMC_API_OBJS) $(KFF_OBJS) $(KMC_TOOLS_OBJS): %.o: %.cpp
++	$(CC) $(CFLAGS) -c $< -o $@
++
++$(KMC_CORE_OBJS): %.o: %.cpp $(SIMDE_DIR)
+ 	$(CC) $(CFLAGS) -c $< -o $@
+ 
+ $(KMC_MAIN_DIR)/raduls_sse2.o: $(KMC_MAIN_DIR)/raduls_sse2.cpp
+@@ -125,6 +132,10 @@ $(LIB_KMC_CORE): $(KMC_CORE_OBJS) $(RADULS_OBJS) $(KMC_API_OBJS) $(KFF_OBJS)
+ 	-mkdir -p $(OUT_BIN_DIR)
+ 	ar rcs $@ $^
+ 
++simde: $(SIMDE_DIR)
++
++kmc_core: $(KMC_CORE_OBJS)
++
+ kmc: $(KMC_CLI_OBJS) $(LIB_KMC_CORE)
+ 	-mkdir -p $(OUT_BIN_DIR)
+ 	$(CC) $(CLINK) -o $(OUT_BIN_DIR)/$@ $^ $(KMC_LIBS)
+@@ -150,6 +161,7 @@ py_kmc_api: $(PY_KMC_API_OBJS) $(PY_KMC_API_OBJS)
+ 
+ clean:
+ 	-rm -f $(KMC_MAIN_DIR)/*.o
++	-rm -rf $(SIMDE_DIR)
+ 	-rm -f $(KMC_API_DIR)/*.o
+ 	-rm -f $(KMC_DUMP_DIR)/*.o
+ 	-rm -f $(KMC_TOOLS_DIR)/*.o
+diff --git a/kmc_CLI/kmc.cpp b/kmc_CLI/kmc.cpp
+index 15e579e..1d62040 100644
+--- a/kmc_CLI/kmc.cpp
++++ b/kmc_CLI/kmc.cpp
+@@ -1,5 +1,7 @@
+ #define _CRT_SECURE_NO_WARNINGS
+ #include "../kmc_core/kmc_runner.h"
++#include <random>
++#include <algorithm>
+ #include <cstring>
+ #include <iostream>
+ #include <fstream>
+@@ -246,6 +248,9 @@ bool parse_parameters(int argc, char* argv[], Params& params)
+ 		stage2Params.SetOutputFileName(argv[i++]);
+ 	stage1Params.SetTmpPath(argv[i++]);
+ 
++	std::random_device rd;
++	std::mt19937 g(rd());
++
+ 	std::vector<std::string> input_file_names;	
+ 	if (input_file_name[0] != '@')
+ 		input_file_names.push_back(input_file_name);
+@@ -264,7 +269,7 @@ bool parse_parameters(int argc, char* argv[], Params& params)
+ 				input_file_names.push_back(s);
+ 
+ 		in.close();
+-		std::random_shuffle(input_file_names.begin(), input_file_names.end());
++		std::shuffle(input_file_names.begin(), input_file_names.end(), g);
+ 	}
+ 	stage1Params.SetInputFiles(input_file_names);
+ 
+diff --git a/kmc_api/kmer_defs.h b/kmc_api/kmer_defs.h
+index 90b0db4..4fe8aaf 100644
+--- a/kmc_api/kmer_defs.h
++++ b/kmc_api/kmer_defs.h
+@@ -34,7 +34,7 @@
+ 
+ 
+ 	#include <stdio.h>
+-	#include <ext/algorithm>
++	#include <algorithm>
+ 	#include <iostream>
+ 
+ #else
+diff --git a/kmc_core/cpu_info.cpp b/kmc_core/cpu_info.cpp
+index 119d748..72d95c3 100644
+--- a/kmc_core/cpu_info.cpp
++++ b/kmc_core/cpu_info.cpp
+@@ -42,13 +42,13 @@ static struct CpuInfoImpl {
+ 
+ 		//it seems clang defined __GNUC__ so __clang__ is checked first, althought in fact it seems __GNUC__ code seems to work also for clang
+ 
+-#elif defined(__clang__)							//basing on https://clang.llvm.org/doxygen/cpuid_8h_source.html
++#elif defined(__GCC_ASM_FLAG_OUTPUTS__) && defined(__clang__)							//basing on https://clang.llvm.org/doxygen/cpuid_8h_source.html
+ 		__asm("xchgq  %%rbx,%q1\n"
+ 		"cpuid\n"
+ 			"xchgq  %%rbx,%q1"
+ 			:"=a"(result[0]), "=r" (result[1]), "=c"(result[2]), "=d"(result[3])
+ 			: "0"(function_id), "c"(0));
+-#elif defined(__GNUC__)								//basing on https://github.com/gcc-mirror/gcc/blob/master/gcc/config/i386/cpuid.h#L187		
++#elif defined(__GCC_ASM_FLAG_OUTPUTS__) && defined(__GNUC__)								//basing on https://github.com/gcc-mirror/gcc/blob/master/gcc/config/i386/cpuid.h#L187		
+ 		__asm__("cpuid\n\t"
+ 			: "=a" (result[0]), "=b" (result[1]), "=c" (result[2]), "=d" (result[3]) : "0" (function_id), "c"(0));
+ #endif  
+@@ -144,4 +144,4 @@ bool CCpuInfo::SSE42_Enabled() { return cpu_info_impl.sse4_2; }
+ bool CCpuInfo::AVX_Enabled() { return cpu_info_impl.avx; }
+ bool CCpuInfo::AVX2_Enabled() { return cpu_info_impl.avx2; }
+ 
+-// ***** EOF
+\ No newline at end of file
++// ***** EOF
+diff --git a/kmc_core/defs.h b/kmc_core/defs.h
+index 75afc97..e0ec1df 100644
+--- a/kmc_core/defs.h
++++ b/kmc_core/defs.h
+@@ -8,6 +8,7 @@
+   Date   : 2022-01-04
+ */
+ 
++
+ #ifndef _DEFS_H
+ #define _DEFS_H
+ 
+@@ -32,6 +33,7 @@
+ 
+ #define COMPACT_CUMSUM_PART_SIZE (1<<10)
+ 
++
+ #define KMER_X		3
+ 
+ #define STATS_FASTQ_SIZE (1 << 28)
+@@ -66,6 +68,7 @@
+ #define MAX_SR		128
+ 
+ //Range of number of sorter threads pre sorter in strict memory mode
++
+ #define MIN_SMSO	1
+ #define MAX_SMSO	16
+ 
+@@ -109,8 +112,8 @@ using uint64 = uint64_t;
+ #include <string.h>
+ 
+ #include <stdio.h>
+-#include <ext/algorithm>
+-using __gnu_cxx::copy_n;
++#include <algorithm>
++//using __gnu_cxx::copy_n;
+ 
+ #endif
+ 
+diff --git a/kmc_core/fastq_reader.h b/kmc_core/fastq_reader.h
+index 7a59897..3cd3771 100644
+--- a/kmc_core/fastq_reader.h
++++ b/kmc_core/fastq_reader.h
+@@ -15,8 +15,8 @@
+ #include "params.h"
+ #include <stdio.h>
+ 
+-#include "libs/zlib.h"
+-#include "libs/bzlib.h"
++#include <bzlib.h>
++#include <zlib.h>
+ 
+ using namespace std;
+ 
+diff --git a/kmc_core/intr_copy.h b/kmc_core/intr_copy.h
+index 59f8c49..840e155 100644
+--- a/kmc_core/intr_copy.h
++++ b/kmc_core/intr_copy.h
+@@ -11,12 +11,13 @@
+ #ifndef _INTR_COPY_H
+ #define _INTR_COPY_H
+ 
++#define SIMDE_ENABLE_NATIVE_ALIASES
++#include "simde/x86/sse2.h" // Analagous to emmintrin.h
++
+ #ifdef _WIN32
+ #include <intrin.h>
+ #endif
+ 
+-#include <emmintrin.h>
+-#include <immintrin.h>
+ #include "critical_error_handler.h"
+ 
+ #ifndef _WIN32
+@@ -95,4 +96,4 @@ template <unsigned SIZE> struct IntrCopy128<SIZE, 0>
+ 
+ #endif
+ 
+-// ***** EOF
+\ No newline at end of file
++// ***** EOF
+diff --git a/kmc_core/queues.h b/kmc_core/queues.h
+index 17a0465..2c0e587 100644
+--- a/kmc_core/queues.h
++++ b/kmc_core/queues.h
+@@ -11,6 +11,8 @@
+ #ifndef _QUEUES_H
+ #define _QUEUES_H
+ 
++#include <algorithm>
++#include <random>
+ #include "defs.h"
+ #include <stdio.h>
+ #include <tuple>
+@@ -571,6 +573,9 @@ public:
+ 	void init_random()
+ 	{
+ 		lock_guard<mutex> lck(mtx);
++	        std::random_device rd;
++		std::mt19937 g(rd());
++ 
+ 		vector<pair<int32, int64>> bin_sizes;
+ 
+ 		for (auto& p : m)
+@@ -589,7 +594,7 @@ public:
+ 		for (uint32 i = no_sort_end; i < bin_sizes.size(); ++i)
+ 			random_bins.push_back(bin_sizes[i].first);
+ 
+-		random_shuffle(random_bins.begin(), random_bins.end());
++		shuffle(random_bins.begin(), random_bins.end(), g);
+ 
+ 		for (uint32 i = no_sort_start; i < no_sort_end; ++i)
+ 			random_bins.push_back(bin_sizes[i].first);

--- a/patches/kmc-v3.2.1_cuttlefish-dev.diff
+++ b/patches/kmc-v3.2.1_cuttlefish-dev.diff
@@ -1,8 +1,8 @@
 diff --git a/Makefile b/Makefile
-index bc07d35..2b351b9 100644
+index bc07d35..5d20bc9 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -13,15 +13,11 @@ OUT_BIN_DIR = bin
+@@ -13,16 +13,12 @@ OUT_BIN_DIR = bin
  OUT_INCLUDE_DIR = include
  
  ifeq ($(UNAME_S),Darwin)
@@ -10,16 +10,18 @@ index bc07d35..2b351b9 100644
 -
 -	CFLAGS	= -Wall -O3 -m64 -static-libgcc -static-libstdc++ -pthread -std=c++14
 -	CLINK	= -lm -static-libgcc -static-libstdc++ -O3 -pthread -std=c++14
-+	CFLAGS	= -Wall -O3 -m64 -pthread -std=c++14
++	CFLAGS	= -Wall -O3 -m64 -pthread -std=c++14 -fPIC 
 +	CLINK	= -lm -lbz2 -lc++ -lz -O3 -pthread -std=c++14
  
  	PY_KMC_API_CFLAGS = -Wl,-undefined,dynamic_lookup -fPIC -Wall -shared -std=c++14 -O3
  else
 -	CC 	= g++
 -
- 	CFLAGS	= -Wall -O3 -m64 -static -Wl,--whole-archive -lpthread -Wl,--no-whole-archive -std=c++14
+-	CFLAGS	= -Wall -O3 -m64 -static -Wl,--whole-archive -lpthread -Wl,--no-whole-archive -std=c++14
++	CFLAGS	= -Wall -O3 -m64 -static -Wl,--whole-archive -lpthread -Wl,--no-whole-archive -std=c++14 -fPIC
  	CLINK	= -lm -static -O3 -Wl,--whole-archive -lpthread -Wl,--no-whole-archive -std=c++14
  
+ 	PY_KMC_API_CFLAGS = -fPIC -Wall -shared -std=c++14 -O3
 @@ -53,15 +49,15 @@ $(KMC_MAIN_DIR)/kmc_runner.o
  ifeq ($(UNAME_S),Darwin)
  	RADULS_OBJS =


### PR DESCRIPTION
Changes:
- Added a new patch to KMC cut from: https://github.com/theJasonFan/KMC/tree/cuttlefish so KMC
  - Uses SIMD Everywhere for intrinsics
  - Builds with appropriate compiler flags to link locally installed `zlib` and `bzip2` libraries
- Updated `CMakeLists.txt` to obtain cache line size from apple arm64 machines with updated sysctl call.
