### PR TITLE
Output polyN stretches in `.cf_seq` file

### DIFF
--- a/include/Oriented_Unitig.hpp
+++ b/include/Oriented_Unitig.hpp
@@ -25,8 +25,8 @@ private:
 
     uint64_t unitig_id;
     cuttlefish::dir_t dir;
-    size_t start_kmer_idx;
-    size_t end_kmer_idx;
+    size_t start_kmer_idx; // Position, on the ref, of the last kmer of the unitig occurrence
+    size_t end_kmer_idx;   // Position, on the ref, of the first kmer of the unitig occurrence
 
     constexpr static uint64_t INVALID_ID = std::numeric_limits<uint64_t>::max();
 

--- a/src/CdBG_GFA_Reduced_Writer.cpp
+++ b/src/CdBG_GFA_Reduced_Writer.cpp
@@ -73,12 +73,15 @@ void CdBG<k>::write_sequence_tiling(Job_Queue<std::string, Oriented_Unitig>& job
             continue;
         }
 
-
         // Write the path ID.
         output << path_id;
 
         // Write the path members.
         output << "\t";
+
+        if(left_unitig.start_kmer_idx > 0) {
+            output << "N" << left_unitig.start_kmer_idx << " ";
+        }
         
         // The first vertex of the path (not inferrable from the path output files).
         output << left_unitig.unitig_id << (left_unitig.dir == cuttlefish::FWD ? "+" : "-");

--- a/src/CdBG_GFA_Writer.cpp
+++ b/src/CdBG_GFA_Writer.cpp
@@ -604,6 +604,23 @@ void CdBG<k>::append_edge_to_path(const uint16_t thread_id, const Oriented_Uniti
     (void)left_unitig;
 
     std::string& buffer = path_buffer[thread_id];
+
+    // Encode polyN stretch
+    // *.{first, last}_kmer_index stores the position of the kmer on the ref.
+    if( (left_unitig.end_kmer_idx + 1) != right_unitig.start_kmer_idx) {
+        // If left_unitig starts at offset 0 and ends at offset k - 1, the smallest polyN stretch of len 1 starts
+        // with index k, and right unitig must start at k+1.
+        if ((right_unitig.start_kmer_idx - left_unitig.end_kmer_idx) < (params.k() + 1)) {
+            // Any difference in idxs < k+1 must be invalid.
+            std::cerr << "ERROR: invalid polyN gap length\n";
+            std::exit(EXIT_FAILURE);
+        }
+        size_t polyn_gap = right_unitig.start_kmer_idx - left_unitig.end_kmer_idx - params.k();
+        buffer += " ";
+        buffer += "N";
+        buffer += fmt::format_int(polyn_gap).c_str();
+    }
+
     buffer += " ";
     buffer += fmt::format_int(right_unitig.unitig_id).c_str();
     buffer += (right_unitig.dir == cuttlefish::FWD ? "+" : "-");


### PR DESCRIPTION
Changed reduced GFA format to output where polyN stretches occur w.r.t output unitig tiling.

PolyN stretches are encoded `N\d`, with `N` prepended to the number of Ns.


Output tilings look like:
```
$ cat tiny.fa        
>I dna:chromosome chromosome:R64-1-1:I:1:230218:1 REF
NNNCACACACCACNCGTATTGAGG
$ cat tiny.cf_seq
Reference:1_Sequence:I	N3 3+ N1 2-
```

@rob-p @jamshed this might be a breaking change for consumers downstream.