### PR TITLE
Avoid implicit type casts, add missing includes

### DIFF
--- a/include/Color_Encoding.hpp
+++ b/include/Color_Encoding.hpp
@@ -2,11 +2,9 @@
 #ifndef COLOR_ENCODING_HPP
 #define COLOR_ENCODING_HPP
 
-
-
-#include <cstdint>
 #include <cassert>
-
+#include <cstddef>
+#include <cstdint>
 
 namespace cuttlefish
 {

--- a/include/RabbitFX/io/Reference.h
+++ b/include/RabbitFX/io/Reference.h
@@ -1,9 +1,10 @@
 #ifndef __REFERENCE_H_
 #define __REFERENCE_H_
 
+#include "Globals.h"
+#include <cstdint>
 #include <string>
 #include <vector>
-#include "Globals.h"
 /**
  * @brief Reference struct that store the FASTA and FASTQ infomation
  */

--- a/src/Discontinuity_Graph_Bootstrap.cpp
+++ b/src/Discontinuity_Graph_Bootstrap.cpp
@@ -49,7 +49,8 @@ void Discontinuity_Graph_Bootstrap<k>::generate()
         const auto seq = parser.seq();
         const auto seq_len = parser.seq_len();
         Minimizer_Iterator<const char*, k - 1, true> min_it(seq, parser.seq_len(), l, minimizer_seed);
-        minimizer_t last_min, last_min_idx, min, min_idx;
+        minimizer_t last_min, min;
+        size_t last_min_idx, min_idx;
 
         Kmer<k> first_vertex;   // First discontinuity k-mer in the sequence.
         Kmer<k> last_vertex;    // Last discontinuity k-mer preceding the current k-mer.

--- a/src/Parser.cpp
+++ b/src/Parser.cpp
@@ -174,8 +174,8 @@ void Parser::consume_split_super_kmers(fq_chunk_pool_t& chunk_pool, fq_chunk_que
                 t_e = timer::now();
                 t.min_it_init_time += timer::duration(t_e - t_s);
 
-                minimizer_t last_min, last_min_idx;
-                minimizer_t min, min_idx;
+                minimizer_t last_min, min;
+                size_t last_min_idx, min_idx;
                 min_it.value_at(last_min, last_min_idx);
                 frag_len = k;
 

--- a/src/Subgraphs_Manager.cpp
+++ b/src/Subgraphs_Manager.cpp
@@ -268,11 +268,11 @@ void Subgraphs_Manager<k, Colored_>::process()
     std::cerr << "Total work in bucket removal:     " << sum_time(t_bucket_rm) << " (s).\n";
 
     std::cerr << "Maximum k-mer count in bucket: " <<
-        [&](){  std::size_t max_sz = 0;
+        [&](){  uint64_t max_sz = 0;
                 std::for_each(max_kmer_count.cbegin(), max_kmer_count.cend(), [&](const auto& v){ max_sz = std::max(max_sz, v.unwrap()); });
                 return max_sz; }() << ".\n";
     std::cerr << "Minimum k-mer count in bucket: " <<
-        [&](){  std::size_t min_sz = std::numeric_limits<uint64_t>::max();
+        [&](){  uint64_t min_sz = std::numeric_limits<uint64_t>::max();
                 std::for_each(min_kmer_count.cbegin(), min_kmer_count.cend(), [&](const auto& v){ min_sz = std::min(min_sz, v.unwrap()); });
                 return min_sz; }() << ".\n";
     const auto sum_g_sz = [&](){ std::size_t sz = 0;


### PR DESCRIPTION
This PR  adds two missing includes (`cstddef` in `Color_Encoding` and `cstdint` in `RabbitFX`) and changes the type of some variables (minimizer index and bucket count) to make clang happy.

Adding the missing includes also fixes https://github.com/COMBINE-lab/cuttlefish/issues/50.