### PR TITLE
Make parallel gzip optional in RabbitFX and tests

### DIFF
--- a/include/RabbitFX/io/FileReader.cpp
+++ b/include/RabbitFX/io/FileReader.cpp
@@ -1,7 +1,9 @@
 
 #include "FileReader.h"
 
+#if defined(USE_IGZIP)
 #include "rapidgzip/ParallelGzipReader.hpp"
+#endif
 
 
 namespace rabbit
@@ -11,9 +13,9 @@ FileReader::FileReader(const std::string &fileName_, bool isZipped, const std::s
     if(ends_with(fileName_, ".gz") || isZipped) {
 
         this->isZipped = true;
+        
+        #if defined(USE_IGZIP)
         par_deflate = (worker_count > 1);
-
-#if defined(USE_IGZIP)
         if(par_deflate)
         {
             auto file_reader = std::make_unique<StandardFileReader>(fileName_);

--- a/src/test.cpp
+++ b/src/test.cpp
@@ -1193,8 +1193,9 @@ void iterate_subgraphs(const std::string& bin_dir, const std::size_t bin_c)
 
 #include <memory>
 #include <functional>
+#if defined(USE_IGZIP)
 #include "rapidgzip/ParallelGzipReader.hpp"
-
+#endif
 
 int main(int argc, char** argv)
 {


### PR DESCRIPTION
This PR allows the code to be compiled when `USE_IGZIP` is disabled.