### PR TITLE
Instructions for Homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,17 @@ and forward-looking implementation of Cuttlefish 3.
 ## Installation
 
 Prebuilt binaries for Linux and macOS (x86-64 and arm64) are attached to each
-[GitHub release](https://github.com/COMBINE-lab/cuttlefish/releases), or via
-[bioconda](https://bioconda.github.io/recipes/cuttlefish/README.html):
+[GitHub release](https://github.com/COMBINE-lab/cuttlefish/releases), [Homebrew](https://formulae.brew.sh/formula/cuttlefish), or via
+[Bioconda](https://bioconda.github.io/recipes/cuttlefish/README.html):
+
+
+Homebrew:
+
+```bash
+brew install cuttlefish
+```
+
+Bioconda
 
 ```bash
 conda install -c bioconda cuttlefish

--- a/website/src/content/docs/rust/installation.md
+++ b/website/src/content/docs/rust/installation.md
@@ -1,6 +1,6 @@
 ---
 title: Installation
-description: Installing Cuttlefish 3 from a prebuilt binary, bioconda, crates.io, or source.
+description: Installing Cuttlefish 3 from a prebuilt binary, bioconda, crates.io, Homebrew, or source.
 ---
 
 ## Prebuilt binaries
@@ -43,6 +43,14 @@ RUSTFLAGS="-C target-cpu=native" cargo install cuttlefish-rs-cli
 shared clusters, a head-node-tuned binary can crash on older compute nodes.
 The [prebuilt release binaries](#prebuilt-binaries) assume x86-64-v3, i.e.
 Haswell 2013 or newer, on x86-64.)
+
+## From Homebrew
+
+If you use [Homebrew](https://brew.sh), installing Cuttlefish is straightforward:
+
+```bash
+brew install cuttlefish
+```
 
 ## From source
 


### PR DESCRIPTION
Cuttlefish is now [available](https://github.com/Homebrew/homebrew-core/commit/64e32dc3a271e0ad121a2e4ebc05388b013fa9a3) to install via [Homebrew](https://brew.sh).

Fixes #61.